### PR TITLE
Revert "Fix tests failing due to path separator differences on Windows"

### DIFF
--- a/pkg/provisioner/ansible_test.go
+++ b/pkg/provisioner/ansible_test.go
@@ -1,8 +1,6 @@
 package provisioner
 
 import (
-	"fmt"
-	"os"
 	"reflect"
 	"testing"
 )
@@ -49,7 +47,7 @@ func TestAnsibleProvisioner_GetCommand(t *testing.T) {
 				"local",
 				"--inventory",
 				"localhost,",
-				fmt.Sprintf("tests%cplaybook.yml", os.PathSeparator),
+				"tests/playbook.yml",
 			},
 		},
 	}

--- a/pkg/verifier/goss_test.go
+++ b/pkg/verifier/goss_test.go
@@ -1,8 +1,6 @@
 package verifier
 
 import (
-	"fmt"
-	"os"
 	"reflect"
 	"testing"
 )
@@ -43,7 +41,7 @@ func TestGossVerifier_GetCommand(t *testing.T) {
 			want1: "goss",
 			want2: []string{
 				"--gossfile",
-				fmt.Sprintf("tests%cgoss.yaml", os.PathSeparator),
+				"tests/goss.yaml",
 				"validate",
 			},
 		},
@@ -62,7 +60,7 @@ func TestGossVerifier_GetCommand(t *testing.T) {
 			want1: "goss",
 			want2: []string{
 				"--gossfile",
-				fmt.Sprintf("tests%cgossfile.yaml", os.PathSeparator),
+				"tests/gossfile.yaml",
 				"validate",
 				"--format",
 				"json",


### PR DESCRIPTION
This is not correct since we have to use UNIX-style path separators for Docker execs.