### PR TITLE
Add no-destroy flag for test subcommand

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -9,14 +9,17 @@ import (
 	"github.com/z0mbix/rolecule/pkg/config"
 )
 
+var noDestroy bool
+
 func init() {
+	testCmd.Flags().BoolVarP(&noDestroy, "no-destroy", "n", false, "don't destroy containers after completion")
 	rootCmd.AddCommand(testCmd)
 }
 
 var testCmd = &cobra.Command{
 	Use:     "test",
 	Aliases: []string{"t"},
-	Short:   "Create the container(s), converge them, test them, then clean up",
+	Short:   "Create the container(s), converge them, and test them",
 	Long: `"test" will create the containers defined, run the provisioner of choice
 against them, test them with your verifier of choice, then destroy everything.`,
 
@@ -41,9 +44,10 @@ against them, test them with your verifier of choice, then destroy everything.`,
 			log.Fatal(err.Error())
 		}
 
-		err = destroy(cfg)
-		if err != nil {
-			log.Fatal(err.Error())
+		if !noDestroy {
+			if err = destroy(cfg); err != nil {
+				log.Fatal(err.Error())
+			}
 		}
 
 		log.Info("complete")


### PR DESCRIPTION
In an ideal world, we would never reuse containers to ensure that the tests run on a clean slate. In complicated roles, re-provisioning a container each time may be too slow because you can't leverage caching of any kind. An example of a task you might not want to keep repeating is one that pulls a large binary over HTTPS.