### PR TITLE
ubuntu-22.04: add gpg-agent

### DIFF
--- a/testing/ansible/ubuntu-22.04-systemd.Dockerfile
+++ b/testing/ansible/ubuntu-22.04-systemd.Dockerfile
@@ -7,7 +7,7 @@ RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 
 # hadolint ignore=DL3008
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates software-properties-common systemd curl cron less sudo bash iproute2 net-tools vim \
+  && apt-get install -y --no-install-recommends ca-certificates software-properties-common systemd curl cron gpg-agent less sudo bash iproute2 net-tools vim \
   && apt-add-repository -y ppa:ansible/ansible 1>/dev/null \
   && apt-get install -y --no-install-recommends ansible ansible-lint \
   && apt-get clean \


### PR DESCRIPTION
The docker build failed for me with the below error unless you add gpg-agent.

not sure if the reason you didn't see this error was due to docker arch. i wouldn't expect it, but that's the only thing i can think of.

```
11.26 Processing triggers for dbus (1.12.20-2ubuntu4.1) ...
12.44 gpg: error running '/usr/bin/gpg-agent': probably not installed
12.44 gpg: failed to start agent '/usr/bin/gpg-agent': Configuration error
12.44 gpg: can't connect to the agent: Configuration error
12.44 Traceback (most recent call last):
12.44   File "/usr/lib/python3/dist-packages/softwareproperties/shortcuthandler.py", line 423, in add_key
12.44     subprocess.run(cmd.split(), check=True, input=keys)
12.44   File "/usr/lib/python3.10/subprocess.py", line 526, in run
12.44     raise CalledProcessError(retcode, process.args,
12.44 subprocess.CalledProcessError: Command '['gpg', '-q', '--no-options', '--no-default-keyring', '--batch', '--keyring', '/etc/apt/trusted.gpg.d/ansible-ubuntu-ansible.gpg', '--homedir', '/tmp/tmp7tdzu1gk', '--import']' returned non-zero exit status 2.
12.44 
12.44 During handling of the above exception, another exception occurred:
12.44 
12.44 Traceback (most recent call last):
12.44   File "/usr/bin/apt-add-repository", line 364, in <module>
12.44     sys.exit(0 if addaptrepo.main() else 1)
12.44   File "/usr/bin/apt-add-repository", line 357, in main
12.44     shortcut.add()
12.44   File "/usr/lib/python3/dist-packages/softwareproperties/shortcuthandler.py", line 222, in add
12.44     self.add_key()
12.44   File "/usr/lib/python3/dist-packages/softwareproperties/shortcuthandler.py", line 425, in add_key
12.44     raise ShortcutException(e)
12.44 softwareproperties.shortcuthandler.ShortcutException: Command '['gpg', '-q', '--no-options', '--no-default-keyring', '--batch', '--keyring', '/etc/apt/trusted.gpg.d/ansible-ubuntu-ansible.gpg', '--homedir', '/tmp/tmp7tdzu1gk', '--import']' returned non-zero exit status 2.
------

 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 38)
ubuntu-22.04-systemd.Dockerfile:9
--------------------
   8 |     # hadolint ignore=DL3008
   9 | >>> RUN apt-get update \
  10 | >>>   && apt-get install -y --no-install-recommends ca-certificates software-properties-common systemd curl cron less sudo bash iproute2 net-tools vim \
  11 | >>>   && apt-add-repository -y ppa:ansible/ansible 1>/dev/null \
  12 | >>>   && apt-get install -y --no-install-recommends ansible ansible-lint \
  13 | >>>   && apt-get clean \
  14 | >>>   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
  15 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update   && apt-get install -y --no-install-recommends ca-certificates software-properties-common systemd curl cron less sudo bash iproute2 net-tools vim   && apt-add-repository -y ppa:ansible/ansible 1>/dev/null   && apt-get install -y --no-install-recommends ansible ansible-lint   && apt-get clean   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*" did not complete successfully: exit code: 1
error: Recipe `build-docker-ansible-images` failed on line 33 with exit code 1
```