### PR TITLE
docker: support referencing env vars in rolecule.yml

### DIFF
--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/apex/log"
@@ -33,8 +34,10 @@ func (p *DockerEngine) Exec(containerName string, envVars map[string]string, cmd
 	}
 
 	for k, v := range envVars {
+		// Expand environment variables within the value if they exist using os.ExpandEnv
+		expandedValue := os.ExpandEnv(v)
 		execArgs = append(execArgs, "--env")
-		execArgs = append(execArgs, fmt.Sprintf("%s=%s", k, v))
+		execArgs = append(execArgs, fmt.Sprintf("%s=%s", k, expandedValue))
 	}
 
 	execArgs = append(execArgs, containerName)

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -29,15 +29,12 @@ func (p *DockerEngine) Run(image string, args []string) (string, error) {
 }
 
 func (p *DockerEngine) Exec(containerName string, envVars map[string]string, cmd string, args []string) error {
-	execArgs := []string{
-		"exec",
-	}
+	execArgs := []string{"exec"}
 
 	for k, v := range envVars {
 		// Expand environment variables within the value if they exist using os.ExpandEnv
-		expandedValue := os.ExpandEnv(v)
 		execArgs = append(execArgs, "--env")
-		execArgs = append(execArgs, fmt.Sprintf("%s=%s", k, expandedValue))
+		execArgs = append(execArgs, fmt.Sprintf("%s=%s", k, os.ExpandEnv(v)))
 	}
 
 	execArgs = append(execArgs, containerName)

--- a/pkg/container/podman.go
+++ b/pkg/container/podman.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/z0mbix/rolecule/pkg/command"
@@ -36,7 +37,7 @@ func (p *PodmanEngine) Exec(containerName string, envVars map[string]string, cmd
 	if len(envVars) > 0 {
 		for k, v := range envVars {
 			execArgs = append(execArgs, "--env")
-			execArgs = append(execArgs, fmt.Sprintf("%s=%s", k, v))
+			execArgs = append(execArgs, fmt.Sprintf("%s=%s", k, os.ExpandEnv(v)))
 		}
 	}
 

--- a/testing/ansible/roles/sysctl/tasks/main.yml
+++ b/testing/ansible/roles/sysctl/tasks/main.yml
@@ -5,7 +5,7 @@
     value: "{{ ansible_swappiness }}"
     state: present
   tags:
-      - provision
+    - provision
 
 - name: output swappiness
   ansible.builtin.debug:


### PR DESCRIPTION
I needed a way to reference local AWS credentials, to test a role that downloaded something from S3 via the AWS env vars.

I'm not sure if there's an existing way of doing this via rolecule, but this seems to work very well.

If the string contains an environment variable (like `$MY_VAR`, or `${MY_VAR}`) and the environment variable is set, it expands the value. If no environment variable is present or recognized, it leaves the string unchanged. If part of the string contains variables and other parts are plain strings, it only expands the variables and leaves the rest as is.

example usage:

`rolecule.yml`:
```
---
engine:
  name: docker

provisioner:
  name: ansible
  env:
    ANSIBLE_HASH_BEHAVIOUR: merge
    AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
    AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
    AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN

verifier:
  name: goss

instances:
  - name: ubuntu-22.04
    image: x.dkr.ecr.eu-west-1.amazonaws.com/ubuntu-22.04-systemd-dind:1.1
```

`playbook.yml`:
```
---
- name: test
  hosts: localhost
  roles:
    - role: sentinel
  vars:
    aws_access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
    aws_secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
    aws_security_token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
```