### PR TITLE
fix: Use forward slashes to construct filepaths for Ansible provisioner

### DIFF
--- a/pkg/provisioner/ansible.go
+++ b/pkg/provisioner/ansible.go
@@ -1,7 +1,6 @@
 package provisioner
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
@@ -122,7 +121,8 @@ func (a AnsibleLocalProvisioner) GetInstallDependenciesCommand() (map[string]str
 }
 
 func (a AnsibleLocalProvisioner) GetCommand() (map[string]string, string, []string) {
-	playbookPath := filepath.Join(testDirectory, a.Playbook)
+	testPlaybook := []string{testDirectory, a.Playbook}
+	playbookPath := strings.Join(testPlaybook, "/")
 	args := a.Args
 
 	for _, tag := range a.Tags {

--- a/pkg/provisioner/ansible.go
+++ b/pkg/provisioner/ansible.go
@@ -122,7 +122,8 @@ func (a AnsibleLocalProvisioner) GetInstallDependenciesCommand() (map[string]str
 }
 
 func (a AnsibleLocalProvisioner) GetCommand() (map[string]string, string, []string) {
-	playbookPath := filepath.Join(testDirectory, a.Playbook)
+	testPlaybook := []string{testDirectory, a.Playbook}
+	playbookPath := strings.Join(testPlaybook, "/")
 	args := a.Args
 
 	for _, tag := range a.Tags {

--- a/pkg/provisioner/ansible_test.go
+++ b/pkg/provisioner/ansible_test.go
@@ -1,8 +1,8 @@
 package provisioner
 
 import (
-	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -48,7 +48,7 @@ func TestAnsibleProvisioner_GetCommand(t *testing.T) {
 				"local",
 				"--inventory",
 				"localhost,",
-				filepath.Join("tests", "playbook.yml"),
+				strings.Join([]string{"tests", "playbook.yml"}, "/"),
 			},
 		},
 	}
@@ -467,7 +467,7 @@ func TestAnsibleLocalProvisioner_GetCommand(t *testing.T) {
 				"local",
 				"--inventory",
 				"localhost,",
-				filepath.Join("tests", "playbook.yml"),
+				strings.Join([]string{"tests", "playbook.yml"}, "/"),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes the same filepath construction issue that was corrected in the container creation logic by always using forward slashes for filepaths that are accessed inside the container used for testing.

Tests came back clean with these changes on my end:
`ok  	github.com/z0mbix/rolecule/pkg/provisioner	0.256s	coverage: 45.9% of statements`

Without fix:
```
   • converging container rolecule-opkssh-ubuntu-systemd with ansible
   • executing interactive command: C:\ProgramData\chocolatey\bin\docker.exe exec --env ANSIBLE_ROLES_PATH=/etc/ansible/roles --env ANSIBLE_NOCOWS=True rolecule-opkssh-ubuntu-systemd ansible-playbook --connection local --inventory localhost, tests\playbook.yml
ERROR! the playbook: tests\playbook.yml could not be found
   ⨯ command failed: exit status 1
```

With fix:
```   
   • converging container rolecule-opkssh-ubuntu-systemd with ansible
   • executing interactive command: C:\ProgramData\chocolatey\bin\docker.exe exec --interactive --tty --env ANSIBLE_NOCOWS=True --env ANSIBLE_ROLES_PATH=/etc/ansible/roles rolecule-opkssh-ubuntu-systemd ansible-playbook --connection local --inventory localhost, tests/playbook.yml

PLAY [test] ************************************************************************************************************
...
```