### PR TITLE
feat: add support for managing nested dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ provisioner:
 
 If you have role dependencies in your `meta/main.yml` file using local roles in the same location
 as the current role, they will be mounted at `/etc/ansible/roles` in the container so
-ansible can find them. Currently , only local roles and ansible galaxy roles are supported.
+ansible can find them. Currently, only local roles and ansible galaxy roles are supported.
 
 ## Instances
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ provisioner:
 
 If you have role dependencies in your `meta/main.yml` file using local roles in the same location
 as the current role, they will be mounted at `/etc/ansible/roles` in the container so
-ansible can find them.
+ansible can find them. Currently , only local roles and ansible galaxy roles are supported.
 
 ## Instances
 
@@ -245,7 +245,7 @@ instances:
 
 If you don't specify the arch, it will use the current host's architecture
 
-Please note that id you do want to test using a different architecture to the host your are running it on,
+Please note that if you do want to test using a different architecture to the host your are running it on,
 you will need to have the relevant container image for that architecture.
 
 ## Verifiers
@@ -335,12 +335,11 @@ are discovered automatically by ansible.
 - ~~Test docker on Linux~~
 - ~~Make provisioner output unbuffered~~
 - ~~Support installing role dependencies~~
-- Support installing ansible collections
-- Support testinfra verifier
+- Support installing ansible collections?
 - ~~Support scenarios, making it possible to test a role with different tags~~
 - ~~Support using custom provisioner command/args/env vars from rolecule.yml~~
-- ~~Support using custom verifier command/args/env vars from rolecule.yml~~/%s
-- Implement `rolecule init` to generate a rolecule.yml file (use current directory structure to determine configuration management provisioner)
+- ~~Support using custom verifier command/args/env vars from rolecule.yml~~
+- ~~Implement `rolecule init` to generate a rolecule.yml file (use current directory structure to determine configuration management provisioner)~~
 - ~~Implement `rolecule list` subcommand to list all running containers~~
 - ~~Write some tests :/~~
 - ~~Document what is required for a container image~~

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -18,3 +18,13 @@ func FileExists(path string) bool {
 	}
 	return false
 }
+
+// ReadFile reads the entire file at path and returns its contents
+func ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// GetCurrentDir returns the current working directory
+func GetCurrentDir() (string, error) {
+	return os.Getwd()
+}

--- a/pkg/provisioner/ansible_metadata.go
+++ b/pkg/provisioner/ansible_metadata.go
@@ -1,68 +1,275 @@
 package provisioner
 
 import (
-	"os"
+	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/apex/log"
+	"github.com/z0mbix/rolecule/pkg/filesystem"
 	"gopkg.in/yaml.v3"
 )
 
+// RoleMetadata represents the metadata of an Ansible role
 type RoleMetadata struct {
-	Collections  []string `yaml:"collections"`
-	Dependencies []struct {
-		Role string `yaml:"role"`
-	} `yaml:"dependencies"`
+	Dependencies []interface{}   `yaml:"dependencies"`
+	resolvedDeps map[string]bool // To keep track of already resolved dependencies
+	localPath    string          // Path to the role directory
 }
 
-func (md *RoleMetadata) LocalDependencies() []string {
-	var roles []string
-
-	for _, dep := range md.Dependencies {
-		// if role name does not contain a dot it is a local role
-		if !strings.Contains(dep.Role, ".") {
-			roles = append(roles, dep.Role)
-		}
-	}
-
-	return roles
-}
-
-func (md *RoleMetadata) GalaxyDependencies() []string {
-	var roles []string
-
-	for _, dep := range md.Dependencies {
-		// if role name contains a dot it is a galaxy role
-		if strings.Contains(dep.Role, ".") {
-			roles = append(roles, dep.Role)
-		}
-	}
-
-	return roles
-}
-
-// GetRoleMetadata parses the role meta/main.yml file
-// and returns a RoleMetadata struct
+// GetRoleMetadata reads the role metadata from meta/main.yml
 func GetRoleMetadata() (*RoleMetadata, error) {
-	metaFile := "meta/main.yml"
-	if _, err := os.Stat(metaFile); os.IsNotExist(err) {
-		return &RoleMetadata{}, nil
-	}
-
-	// Open the meta/main.yml file
-	file, err := os.Open(metaFile)
+	metadataFile := "meta/main.yml"
+	data, err := filesystem.ReadFile(metadataFile)
 	if err != nil {
-		return &RoleMetadata{}, err
+		return nil, fmt.Errorf("failed to read metadata file: %w", err)
 	}
-	defer file.Close()
 
-	// Create a RoleMetadata struct to hold the parsed data
 	var metadata RoleMetadata
-
-	// Decode the YAML file into the RoleMetadata struct
-	decoder := yaml.NewDecoder(file)
-	if err := decoder.Decode(&metadata); err != nil {
-		return &RoleMetadata{}, err
+	if err := yaml.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
 	}
+
+	cwd, err := filesystem.GetCurrentDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	metadata.localPath = filepath.Dir(cwd)
+	metadata.resolvedDeps = make(map[string]bool)
 
 	return &metadata, nil
+}
+
+// AllLocalDependencies returns a complete list of all local dependencies (including nested ones)
+// and a map of role mount paths for use in container setup
+func (rm *RoleMetadata) AllLocalDependencies() ([]string, map[string]string, error) {
+	allDeps := []string{}
+	roleMounts := make(map[string]string)
+
+	// Get direct and nested local dependencies
+	localDeps := rm.LocalDependencies()
+
+	// Generate mount paths for all dependencies
+	for _, dep := range localDeps {
+		srcPath := filepath.Join(rm.localPath, dep)
+		dstPath := filepath.Join("/etc/ansible/roles", dep)
+		roleMounts[srcPath] = dstPath
+		allDeps = append(allDeps, dep)
+
+		log.Debugf("adding mount for dependency %s: %s -> %s", dep, srcPath, dstPath)
+	}
+
+	return allDeps, roleMounts, nil
+}
+
+// LocalDependencies returns the list of local dependencies (both direct and nested)
+func (rm *RoleMetadata) LocalDependencies() []string {
+	var localDeps []string
+	depSet := make(map[string]bool) // Use a map to avoid duplicates
+
+	// First, collect direct dependencies
+	for _, dep := range rm.parseDependencies() {
+		// Check if it's a local role (not a galaxy role)
+		if !strings.Contains(dep, ".") && !strings.Contains(dep, "/") {
+			if !depSet[dep] {
+				depSet[dep] = true
+				localDeps = append(localDeps, dep)
+
+				// Now recursively resolve dependencies of this dependency
+				log.Debugf("resolving dependencies for role: %s", dep)
+				nestedDeps, err := rm.resolveNestedDependencies(dep)
+				if err != nil {
+					log.Warnf("failed to resolve dependencies for %s: %v", dep, err)
+					continue
+				}
+
+				// Add nested dependencies
+				for _, nestedDep := range nestedDeps {
+					if !depSet[nestedDep] {
+						depSet[nestedDep] = true
+						localDeps = append(localDeps, nestedDep)
+						log.Debugf("added nested dependency: %s", nestedDep)
+					}
+				}
+			}
+		}
+	}
+
+	log.Debugf("all local dependencies: %v", localDeps)
+	return localDeps
+}
+
+// GalaxyDependencies returns the list of galaxy dependencies (both direct and nested)
+func (rm *RoleMetadata) GalaxyDependencies() []string {
+	var galaxyDeps []string
+	galaxyDepSet := make(map[string]bool)
+
+	// Process direct dependencies
+	for _, dep := range rm.parseDependencies() {
+		// Check if it's a galaxy role (contains a dot)
+		if strings.Contains(dep, ".") {
+			if !galaxyDepSet[dep] {
+				galaxyDepSet[dep] = true
+				galaxyDeps = append(galaxyDeps, dep)
+			}
+		} else {
+			// For local roles, we need to check their dependencies too
+			nestedGalaxyDeps, err := rm.resolveNestedGalaxyDependencies(dep)
+			if err != nil {
+				log.Warnf("failed to resolve galaxy dependencies for %s: %v", dep, err)
+				continue
+			}
+
+			// Add nested galaxy dependencies
+			for _, nestedDep := range nestedGalaxyDeps {
+				if !galaxyDepSet[nestedDep] {
+					galaxyDepSet[nestedDep] = true
+					galaxyDeps = append(galaxyDeps, nestedDep)
+					log.Debugf("added nested galaxy dependency: %s", nestedDep)
+				}
+			}
+		}
+	}
+
+	log.Debugf("all galaxy dependencies: %v", galaxyDeps)
+	return galaxyDeps
+}
+
+// resolveNestedDependencies reads the dependencies of a dependency and returns all nested local dependencies
+func (rm *RoleMetadata) resolveNestedDependencies(roleName string) ([]string, error) {
+	var nestedDeps []string
+	depSet := make(map[string]bool) // Track dependencies to avoid duplicates
+
+	// Construct path to the dependency's metadata file
+	depMetaPath := filepath.Join(rm.localPath, roleName, "meta", "main.yml")
+
+	// Check if metadata file exists
+	if !filesystem.FileExists(depMetaPath) {
+		log.Debugf("no metadata file found for role %s at %s", roleName, depMetaPath)
+		return nestedDeps, nil // Return empty slice, not an error
+	}
+
+	// Read and parse the dependency's metadata
+	data, err := filesystem.ReadFile(depMetaPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metadata for %s: %w", roleName, err)
+	}
+
+	var depMetadata RoleMetadata
+	if err := yaml.Unmarshal(data, &depMetadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata for %s: %w", roleName, err)
+	}
+
+	// Set the local path for the dependency
+	depMetadata.localPath = rm.localPath
+
+	// Get dependencies of this dependency
+	for _, dep := range depMetadata.parseDependencies() {
+		// Only process local dependencies
+		if !strings.Contains(dep, ".") && !strings.Contains(dep, "/") {
+			if !depSet[dep] {
+				depSet[dep] = true
+				nestedDeps = append(nestedDeps, dep)
+				log.Debugf("found nested dependency: %s from role: %s", dep, roleName)
+
+				// Recursively get dependencies of this dependency
+				subDeps, err := rm.resolveNestedDependencies(dep)
+				if err != nil {
+					log.Warnf("failed to resolve sub-dependencies for %s: %v", dep, err)
+					continue
+				}
+
+				// Add sub-dependencies
+				for _, subDep := range subDeps {
+					if !depSet[subDep] {
+						depSet[subDep] = true
+						nestedDeps = append(nestedDeps, subDep)
+						log.Debugf("added sub-dependency: %s from role: %s", subDep, dep)
+					}
+				}
+			}
+		}
+	}
+
+	return nestedDeps, nil
+}
+
+// resolveNestedGalaxyDependencies reads the dependencies of a dependency and returns all nested galaxy dependencies
+func (rm *RoleMetadata) resolveNestedGalaxyDependencies(roleName string) ([]string, error) {
+	var galaxyDeps []string
+	galaxyDepSet := make(map[string]bool) // Track dependencies to avoid duplicates
+
+	// Construct path to the dependency's metadata file
+	depMetaPath := filepath.Join(rm.localPath, roleName, "meta", "main.yml")
+
+	// Check if metadata file exists
+	if !filesystem.FileExists(depMetaPath) {
+		log.Debugf("no metadata file found for role %s at %s", roleName, depMetaPath)
+		return galaxyDeps, nil // Return empty slice, not an error
+	}
+
+	// Read and parse the dependency's metadata
+	data, err := filesystem.ReadFile(depMetaPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metadata for %s: %w", roleName, err)
+	}
+
+	var depMetadata RoleMetadata
+	if err := yaml.Unmarshal(data, &depMetadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata for %s: %w", roleName, err)
+	}
+
+	// Set the local path for the dependency
+	depMetadata.localPath = rm.localPath
+
+	// Get dependencies of this dependency
+	for _, dep := range depMetadata.parseDependencies() {
+		// Process galaxy dependencies
+		if strings.Contains(dep, ".") || strings.Contains(dep, "/") {
+			if !galaxyDepSet[dep] {
+				galaxyDepSet[dep] = true
+				galaxyDeps = append(galaxyDeps, dep)
+				log.Debugf("found nested galaxy dependency: %s from role: %s", dep, roleName)
+			}
+		} else {
+			// For local roles, check their galaxy dependencies
+			nestedGalaxyDeps, err := rm.resolveNestedGalaxyDependencies(dep)
+			if err != nil {
+				log.Warnf("failed to resolve nested galaxy dependencies for %s: %v", dep, err)
+				continue
+			}
+
+			// Add nested galaxy dependencies
+			for _, nestedDep := range nestedGalaxyDeps {
+				if !galaxyDepSet[nestedDep] {
+					galaxyDepSet[nestedDep] = true
+					galaxyDeps = append(galaxyDeps, nestedDep)
+					log.Debugf("added nested galaxy dependency: %s from role: %s", nestedDep, dep)
+				}
+			}
+		}
+	}
+
+	return galaxyDeps, nil
+}
+
+// parseDependencies parses the dependencies field and returns a list of role names
+func (rm *RoleMetadata) parseDependencies() []string {
+	var dependencies []string
+
+	for _, dep := range rm.Dependencies {
+		switch v := dep.(type) {
+		case string:
+			dependencies = append(dependencies, v)
+		case map[string]interface{}:
+			if name, ok := v["name"].(string); ok {
+				dependencies = append(dependencies, name)
+			} else if role, ok := v["role"].(string); ok {
+				dependencies = append(dependencies, role)
+			}
+		}
+	}
+
+	return dependencies
 }

--- a/testing/ansible/roles/simple/meta/main.yml
+++ b/testing/ansible/roles/simple/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: sshd

--- a/testing/ansible/roles/simple/tests/playbook.yml
+++ b/testing/ansible/roles/simple/tests/playbook.yml
@@ -1,4 +1,3 @@
----
 - name: test
   hosts: localhost
   roles:

--- a/testing/ansible/roles/sshd/meta/main.yml
+++ b/testing/ansible/roles/sshd/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: sysctl

--- a/testing/ansible/roles/sshd/tasks/main.yml
+++ b/testing/ansible/roles/sshd/tasks/main.yml
@@ -1,4 +1,8 @@
----
+- name: Include OS-specific variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - always
+
 - name: package
   ansible.builtin.package:
     name: openssh-server

--- a/testing/ansible/roles/sshd/vars/Debian.yml
+++ b/testing/ansible/roles/sshd/vars/Debian.yml
@@ -1,0 +1,1 @@
+sshd_service_name: ssh

--- a/testing/ansible/roles/sshd/vars/RedHat.yml
+++ b/testing/ansible/roles/sshd/vars/RedHat.yml
@@ -1,0 +1,1 @@
+sshd_service_name: sshd

--- a/testing/ansible/roles/sysctl/meta/main.yml
+++ b/testing/ansible/roles/sysctl/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - role: simple

--- a/testing/ansible/roles/sysctl/tests/playbook.yml
+++ b/testing/ansible/roles/sysctl/tests/playbook.yml
@@ -1,4 +1,3 @@
----
 - name: test
   hosts: localhost
   roles:

--- a/testing/ansible/roles/sysctl/tests/rolecule.yml
+++ b/testing/ansible/roles/sysctl/tests/rolecule.yml
@@ -1,4 +1,3 @@
----
 engine:
   name: docker
 

--- a/testing/ansible/roles/website/tests/playbook.yml
+++ b/testing/ansible/roles/website/tests/playbook.yml
@@ -1,5 +1,8 @@
----
 - name: test
   hosts: localhost
+  pre_tasks:
+    - name: update apt cache
+      ansible.builtin.apt:
+        update_cache: yes
   roles:
     - website


### PR DESCRIPTION
@gurpalw Can you please test this branch with your roles to make sure it works for you. I have tested this with the `website` role in `./testing/ansible/roles/website`, which depends on two galaxy roles, and the local `simple` role, which depends on the `sysctl` role.

Inside the container after a converge, I now have:

```
# ls -1 /etc/ansible/roles/
geerlingguy.nginx
geerlingguy.redis
simple
sshd
sysctl
website
```

This closes issue #12 